### PR TITLE
Attempt to extend SchemaBase to allow '^x-' OpenAPI extensions

### DIFF
--- a/fastapi/openapi/models.py
+++ b/fastapi/openapi/models.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 from fastapi.logger import logger
-from pydantic import AnyUrl, BaseModel, Field
+from pydantic import AnyUrl, BaseModel, Field, root_validator
 
 try:
     import email_validator
@@ -116,6 +116,18 @@ class SchemaBase(BaseModel):
     externalDocs: Optional[ExternalDocumentation] = None
     example: Optional[Any] = None
     deprecated: Optional[bool] = None
+
+    class Config:
+        extras = "allow"
+
+    @root_validator(pre=False,)
+    def validate_openapi_extensions(cls, values):
+        import re
+
+        valid_extension = re.compile("^x-")
+        values = {k: v for k, v in values.items() if valid_extension.match(k) or k in cls.schema()["properties"]}
+
+        return values
 
 
 class Schema(SchemaBase):


### PR DESCRIPTION
## MWE

Starting from this simple app:

```json
import json
from pydantic import BaseModel, Field
from fastapi import FastAPI, APIRouter


class Model(BaseModel):

    data: int = Field(
        ...,
        description="The field with an extension key",
        extra={"x-extension-key": "important metadata"},
    )


router = APIRouter()


@router.get("/model", response_model=Model)
def get_model(request):
    return Model(data=1)


if __name__ == "__main__":
    app = FastAPI()
    app.include_router(router)
    with open("openapi.json", "w") as f:
        json.dump(app.openapi(), f, indent=2)
```

The definition of `Model` in the generated OpenAPI schema (with diff relative to what I would like to happen...) is:

```diff
      "Model": {
        "title": "Model",
        "required": [
          "data"
        ],
        "type": "object",
        "properties": {
          "data": {
            "title": "Data",
            "type": "integer",
            "description": "The field with an extension key",
-           "x-extension-key": "important metadata"
          }
        }
      },
```

and at the moment, with this patch enabled, all schema -> $refs are broken:

```diff
<                 "schema": {}
---
>                 "schema": {
>                   "$ref": "#/components/schemas/Model"
>                 }
35c37,39
<                 "schema": {}
---
>                 "schema": {
>                   "$ref": "#/components/schemas/HTTPValidationError"
>                 }
68c72,73
<             "description": "The field with an extension key"
---
>             "description": "The field with an extension key",
>             "x-extension-key": "important metadata"
100c105
< }
\ No newline at end of file
---
> }